### PR TITLE
Added a Rakefile with test task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+  t.test_files = FileList['test/**/*_test.rb']
+  t.verbose = true
+  t.warning = true
+end
+
+task :default => :test

--- a/lib/multipart_parser/reader.rb
+++ b/lib/multipart_parser/reader.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../parser', __FILE__)
+require 'multipart_parser/parser'
 
 module MultipartParser
   class NotMultipartError < StandardError; end;

--- a/test/multipart_parser/parser_test.rb
+++ b/test/multipart_parser/parser_test.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
-require File.dirname(__FILE__) + "/../../lib/multipart_parser/parser"
-require File.dirname(__FILE__) + "/../fixtures/multipart"
+require "multipart_parser/parser"
+require "fixtures/multipart"
 
 module MultipartParser
   class ParserTest < Test::Unit::TestCase
@@ -85,7 +85,7 @@ module MultipartParser
           end
         end
         unless got_error
-          assert true, end_called
+          assert_equal true, end_called
           assert_equal fixture.parts, parts
         else
           assert fixture.expect_error,


### PR DESCRIPTION
tests may be run with `rake`, expand_path no longer necessary
