### PR TITLE
fix LongBoundary test

### DIFF
--- a/test/fixtures/multipart.rb
+++ b/test/fixtures/multipart.rb
@@ -96,11 +96,11 @@ module MultipartParser::Fixtures
     end
 
     def raw
-      ['----------------------------5c4dc587f69f',
-        'content-disposition: form-data; name="field1"',
-        '',
-        "Joe Blow\r\nalmost tricked you!",
-        '----------------------------5c4dc587f69f--'
+      ['------------------------------5c4dc587f69f',
+       'content-disposition: form-data; name="field1"',
+       '',
+       "Joe Blow\r\nalmost tricked you!",
+       '------------------------------5c4dc587f69f--'
       ].join("\r\n")
     end
   end

--- a/test/multipart_parser/parser_test.rb
+++ b/test/multipart_parser/parser_test.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
-require "multipart_parser/parser"
-require "fixtures/multipart"
+require File.dirname(__FILE__) + "/../../lib/multipart_parser/parser"
+require File.dirname(__FILE__) + "/../fixtures/multipart"
 
 module MultipartParser
   class ParserTest < Test::Unit::TestCase


### PR DESCRIPTION
Hi danabr,

Thank you for the gem.
I found that the fixture of LongBoundary test was not correct, because the raw data lacks '--'.
I also fixed the require path for parser_test as it can work as reader_test.
I tried to use multipart-parser with Ruby 2.3.1 and it runs fine.

Cheers